### PR TITLE
Exposing the test context to each spec

### DIFF
--- a/src/gospec/context.go
+++ b/src/gospec/context.go
@@ -28,6 +28,9 @@ type Context interface {
 	// Makes an assumption. Otherwise the same as an expectation,
 	// but on failure will not continue executing the child specs.
 	Assume(actual interface{}, matcher Matcher, expected ...interface{})
+
+	// Returns the the testing context for the spec
+	TestingContext() *testing.T
 }
 
 type taskContext struct {
@@ -108,6 +111,10 @@ func (c *taskContext) Assume(actual interface{}, matcher Matcher, expected ...in
 	logger := assumptionLogger{c.currentSpec}
 	m := newMatcherAdapter(location, logger, AssumeFailed)
 	m.Expect(actual, matcher, expected...)
+}
+
+func (c *taskContext) TestingContext() *testing.T {
+	return c.testingContext
 }
 
 type expectationLogger struct {

--- a/src/gospec/context.go
+++ b/src/gospec/context.go
@@ -6,6 +6,7 @@ package gospec
 
 import (
 	"container/list"
+	"testing"
 )
 
 // Context controls the execution of the current spec. Child specs can be
@@ -34,6 +35,7 @@ type taskContext struct {
 	currentSpec    *specRun
 	executedSpecs  *list.List
 	postponedSpecs *list.List
+	testingContext *testing.T
 }
 
 func newInitialContext() *taskContext {

--- a/src/gospec/runner.go
+++ b/src/gospec/runner.go
@@ -4,6 +4,8 @@
 
 package gospec
 
+import "testing"
+
 const (
 	channelBufferSize = 10
 )
@@ -14,6 +16,14 @@ type Runner struct {
 	results      chan *taskResult
 	executed     []*specRun
 	scheduled    []*scheduledTask
+	testContext  *testing.T
+}
+
+// Sets the runner test context. Used to aid in exposing
+// the test context to any spec. Example:
+// SetTestContext(t)
+func (r *Runner) SetTestContext(t *testing.T) {
+	r.testContext = t
 }
 
 func NewRunner() *Runner {
@@ -89,6 +99,7 @@ func (r *Runner) nextScheduledTask() *scheduledTask {
 }
 
 func (r *Runner) execute(name string, closure specRoot, c *taskContext) *taskResult {
+	c.testingContext = r.testContext
 	c.Specify(name, func() { closure(c) })
 	return &taskResult{
 		name,


### PR DESCRIPTION
This PR allows the exposure of the runner's test context to each spec, useful for using gospec in conjunction with gomock as per https://github.com/orfjackal/gospec/issues/4
